### PR TITLE
旧ドメインからリダイレクト

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  FQDN = ENV["ALLOWED_HOST"]
+  ALLOWED_HOSTS = [ENV["ALLOWED_HOST"], ENV["ALLOWED_OLD_HOST"]]
+  before_action :ensure_domain
   before_action :set_current_user
 
   def set_current_user
@@ -17,6 +20,23 @@ class ApplicationController < ActionController::Base
     if @current_user
       flash[:notice] = "Ya has iniciado sesión"
       redirect_to("/services/index")
+    end
+  end
+
+  # redirect correct server from herokuapp domain for SEO
+  def ensure_domain
+    return unless /\.herokuapp.com/ =~ request.host
+    
+    # 主にlocalテスト用の対策80と443以外でアクセスされた場合ポート番号をURLに含める 
+    port = ":#{request.port}" unless [80, 443].include?(request.port)
+    redirect_url = "#{request.protocol}#{FQDN}#{port}#{request.path}"
+    redirect_host = URI.parse(redirect_url).host
+    
+    if ALLOWED_HOSTS.include?(redirect_host)
+      redirect_to redirect_url, status: :moved_permanently, allow_other_host: true
+    else
+      # リダイレクト先のホストが許可されていない場合の処理をここに書く
+      render plain: 'Not Allowed', status: :forbidden
     end
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,4 +92,5 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.hosts << ENV["ALLOWED_HOST"]
+  config.hosts << ENV["ALLOWED_OLD_HOST"]
 end


### PR DESCRIPTION
以下の独自ドメインへの設定を行いましたが、
https://www.olumeca.com

同時にHerokuのデフォルトのドメインにもアクセスできるようになっていました。
https://horukuru-deploy-test-7a1df01b3e3f.herokuapp.com

そのため、上記のデフォルトのドメインにアクセスした場合、
独自ドメインにリダイレクトされる設定を追加しました。